### PR TITLE
Reset main to remove test commits

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/tcodes0/go
+
+go 1.22
+
+retract (
+    v0.1.0
+    v0.1.1
+    v0.1.2
+    v0.1.3
+)

--- a/src/dummy/dummy.go
+++ b/src/dummy/dummy.go
@@ -1,0 +1,5 @@
+package dummy
+
+func Dummy() string {
+	return "v0.1.4"
+}

--- a/src/dummy/go.mod
+++ b/src/dummy/go.mod
@@ -1,3 +1,0 @@
-module github.com/tcodes0/go/dummy
-
-go 1.22

--- a/src/dummy/main.go
+++ b/src/dummy/main.go
@@ -1,9 +1,0 @@
-package main
-
-type Dummy interface {
-	func(a string) error
-}
-
-func main() {
-
-}


### PR DESCRIPTION
This PR contains changes for some testing around go module structure. The commits below have been reset from main and force pushed out, to keep main clean; changes are include in this PR. Tags lower than v.0.1.3 have been retracted and contain only test code.

```bash
// main
8ac14bc (HEAD -> main, origin/main) retract old versions
69b43be root go.mod
70c3768 bump (#3)
d1448b1 update dummy (#2)
f107df4 udpate dummy
62bf506 fix package
fafa237 update package module name
bf70e4c test dummy package
85a6dd5 init // kept
(history starts here)
```
